### PR TITLE
fix rerender timeout

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -199,8 +199,10 @@ function patchDMList(PlatformIndicator: ({ user }: { user: User }) => JSX.Elemen
 }
 
 function rerenderRequired(): void {
-  void util.waitFor("[class^=layout-]").then(() => forceRerenderElement("[class^=privateChannels-]"));
-  void util.waitFor("li [class*=message-] h3").then(() => forceRerenderElement("[class^=chat-]"));  
+  void util
+    .waitFor("[class^=layout-]")
+    .then(() => forceRerenderElement("[class^=privateChannels-]"));
+  void util.waitFor("li [class*=message-] h3").then(() => forceRerenderElement("[class^=chat-]"));
 }
 
 export function stop(): void {


### PR DESCRIPTION
![image](https://github.com/Puyodead1/replugged-platformindicators/assets/73281112/8d707013-5cce-4ba4-970a-940230f8690d)
fixes this issue which happens due to await in start
also rerendes chat messages to load indicator in them if they are loaded before plugin